### PR TITLE
Fix typo in google font import

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,6 @@
 @import url("https://unpkg.com/@tailwindcss/typography@0.2.x/dist/typography.min.css");
 @import url("https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css");
-@import url("https://fonts.googleapis.com/css2?family=Amatic+SCLwght@700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Amatic+SC:wght@700&display=swap");
 
 .cursive {
   font-family: "Amatic SC", cursive;


### PR DESCRIPTION
- Replace "L" with a colon